### PR TITLE
Keep v from upstream version and use erigontech/erigon

### DIFF
--- a/erigon/Dockerfile
+++ b/erigon/Dockerfile
@@ -19,7 +19,7 @@ USER root
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-RUN apt-get update && apt-get install curl && \
+RUN apt-get update && apt-get install -y curl && \
     chmod +rx /usr/local/bin/entrypoint.sh /etc/profile.d/execution_tools.sh
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]


### PR DESCRIPTION
According to upstream changelog
> Returned prefix "v" to git tag, docker tags. Reason: compatibility with Golang's rules (go.mod)