### PR TITLE
bump erigontech/erigon to v3.3.9, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "erigontech/erigon",
-      "version": "v3.3.7",
+      "version": "v3.3.9",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: erigon
       args:
-        UPSTREAM_VERSION: v3.3.7
+        UPSTREAM_VERSION: v3.3.9
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /home/erigon/.local/share
     environment:


### PR DESCRIPTION
Bumps upstream version

- [erigontech/erigon](https://github.com/erigontech/erigon) from v3.3.7 to [v3.3.9](https://github.com/erigontech/erigon/releases/tag/v3.3.9)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)