### PR TITLE
bump erigontech/erigon to v3.3.10, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "erigontech/erigon",
-      "version": "v3.3.7",
+      "version": "v3.3.10",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: erigon
       args:
-        UPSTREAM_VERSION: v3.3.7
+        UPSTREAM_VERSION: v3.3.10
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /home/erigon/.local/share
     environment:

--- a/package_variants/gnosis/dappnode_package.json
+++ b/package_variants/gnosis/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnosis-erigon.dnp.dappnode.eth",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "requirements": {
     "minimumDappnodeVersion": "0.3.12",
     "notInstalledPackages": ["nimbus-gnosis.dnp.dappnode.eth"]

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoodi-erigon.dnp.dappnode.eth",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "links": {
     "api": "http://hoodi-erigon.dappnode:8545",
     "apiEngine": "http://hoodi-erigon.dappnode:8551",

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "erigon.dnp.dappnode.eth",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "links": {
     "api": "http://erigon.dappnode:8545",
     "apiEngine": "http://erigon.dappnode:8551",


### PR DESCRIPTION
Bumps upstream version

- [erigontech/erigon](https://github.com/erigontech/erigon) from v3.3.7 to [v3.3.10](https://github.com/erigontech/erigon/releases/tag/v3.3.10)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)