### PR TITLE
Fix missing variant version bumps for erigon v3.3.10

### DIFF
--- a/package_variants/gnosis/dappnode_package.json
+++ b/package_variants/gnosis/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnosis-erigon.dnp.dappnode.eth",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "requirements": {
     "minimumDappnodeVersion": "0.3.12",
     "notInstalledPackages": ["nimbus-gnosis.dnp.dappnode.eth"]

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoodi-erigon.dnp.dappnode.eth",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "links": {
     "api": "http://hoodi-erigon.dappnode:8545",
     "apiEngine": "http://hoodi-erigon.dappnode:8551",

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "erigon.dnp.dappnode.eth",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "links": {
     "api": "http://erigon.dappnode:8545",
     "apiEngine": "http://erigon.dappnode:8551",


### PR DESCRIPTION
PR #76 bumped the upstream erigon version to v3.3.10 but missed the variant version bumps. This adds:

- gnosis: 1.0.5 → 1.0.6
- hoodi: 0.1.2 → 0.1.3  
- mainnet: 1.0.3 → 1.0.4

Should be merged on top of #76 (or squashed into it).