### PR TITLE
Replace staker-test-util docker image with dappnode/tropibot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e MODE=test -e IPFS_HASH=${{ needs.build.outputs.ipfs_hash }} \
             -e GITHUB_TOKEN=${{ steps.app-token.outputs.token }} -e GITHUB_REPOSITORY=${{ github.repository }} -e GITHUB_PR_NUMBER=${{ github.event.pull_request.number }} -e GITHUB_RUN_ID=${{ github.run_id }} -e GITHUB_SERVER_URL=${{ github.server_url }} \
-            ghcr.io/dappnode/staker-test-util/test-runner:latest
+            dappnode/tropibot:latest test-runner
 
   release:
     name: Release

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -48,4 +48,4 @@ jobs:
                     -v /var/run/docker.sock:/var/run/docker.sock \
                     -e MODE=sync -e EXECUTION_CLIENT='erigon' -e IPFS_HASH=${{ needs.build.outputs.ipfs_hash }} -e CONSENSUS_CLIENT=${{ github.event.inputs.consensus_client }} \
                     -e GITHUB_TOKEN=${{ steps.app-token.outputs.token }} -e GITHUB_REPOSITORY=${{ github.repository }} -e GITHUB_PR_NUMBER=${{ github.event.pull_request.number }} -e GITHUB_RUN_ID=${{ github.run_id }} -e GITHUB_SERVER_URL=${{ github.server_url }} \
-                    ghcr.io/dappnode/staker-test-util/test-runner:latest
+                    dappnode/tropibot:latest test-runner

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,7 +23,7 @@ jobs:
             -e EXECUTION_CLIENT='erigon' \
             -e CONSENSUS_CLIENT=${{ github.event.inputs.consensus_client }} \
             -e NETWORK=hoodi \
-            ghcr.io/dappnode/staker-test-util/test-runner:latest
+            dappnode/tropibot:latest test-runner
 
   notify:
     needs: sync


### PR DESCRIPTION
Replace `ghcr.io/dappnode/staker-test-util/test-runner:latest` with `dappnode/tropibot:latest test-runner` in all workflow files.